### PR TITLE
If billed units is a string, convert back to int

### DIFF
--- a/edi_835_parser/segments/service.py
+++ b/edi_835_parser/segments/service.py
@@ -35,6 +35,9 @@ class Service:
 		self.allowed_units = get_element(segment, 5, default=default)
 
 		self.billed_units = get_element(segment, 7, default=self.allowed_units)
+		
+		if isinstance(self.billed_units, str):
+		    self.billed_units = int(float(self.billed_units))
 
 	def __repr__(self):
 		return '\n'.join(str(item) for item in self.__dict__.items())


### PR DESCRIPTION
All 835's come in with an int here, and even the default value you have is an int... however, Cigna, in their infinite wisdom, is using floating point as a string, ex: 100.00 or 25.00 to specify the number of units.

This should covert it back to int to match all the other vendor files.

I had to convert to float first as there is a decimal value of "00" always there.